### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/slides/talk.tex
+++ b/slides/talk.tex
@@ -48,7 +48,7 @@
 \DeclareFieldFormat[article]{volume}{\textbf{#1}}
 \DeclareFieldFormat{doi}{%
   doi\addcolon%
-  {\scriptsize\ifhyperref{\href{http://dx.doi.org/#1}{\nolinkurl{#1}}}
+  {\scriptsize\ifhyperref{\href{https://doi.org/#1}{\nolinkurl{#1}}}
     {\nolinkurl{#1}}}}
 \AtEveryBibitem{%
 \clearfield{pages}%


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update the code that generates new DOI links.

Cheers!